### PR TITLE
Metacritic support

### DIFF
--- a/app/APIs/MetacriticGames.php
+++ b/app/APIs/MetacriticGames.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Morpheus\APIs;
+
+class MetacriticGames {
+	const API_ENDPOINT = 'https://metacritic-2.p.mashape.com/find/game';
+	
+	public function update(\Morpheus\SteamGame $game) {
+		$response = $this->getRawResponse($game->getName());
+		if ($response->result !== false) {
+			$game->metacritic_name = $response->result->name;
+			$game->metacritic_score = $response->result->score;
+			$game->metacritic_userscore = $response->result->userscore;
+			$game->metacritic_genre = $response->result->genre[0];
+			$game->metacritic_publisher = $response->result->publisher;
+			$game->metacritic_developer = $response->result->developer;
+			$game->metacritic_rating = $response->result->rating;
+			$game->metacritic_url = $response->result->url;
+			$game->metacritic_rlsdate = $response->result->rlsdate;
+			$game->metacritic_summary = $response->result->summary;
+			$game->metacritic_updated = date('Y-m-d H:i:s');
+			$game->save();			
+			return 'success';
+		} else {
+			$game->metacritic_updated = date('Y-m-d H:i:s');
+			$game->save();
+			return "failure";
+		}
+	}
+	
+	public function batchUpdate(\Illuminate\Database\Eloquent\Collection $games) {
+		
+	}
+	
+	protected function getRawResponse($name) {
+		$client = new \GuzzleHttp\Client();
+		$response = $client->get(self::API_ENDPOINT, [
+			'query' => [
+				"platform" => 'pc',
+				"title" => $name
+			],
+			"headers" => [
+				"X-Mashape-Key" => env("MASHAPE_API_KEY"),
+				'Accept' => 'application/json',
+			]
+		]);
+		return json_decode($response->getBody());
+	}
+	
+}

--- a/app/APIs/MetacriticGames.php
+++ b/app/APIs/MetacriticGames.php
@@ -4,47 +4,71 @@ namespace Morpheus\APIs;
 
 class MetacriticGames {
 	const API_ENDPOINT = 'https://metacritic-2.p.mashape.com/find/game';
-	
-	public function update(\Morpheus\SteamGame $game) {
-		$response = $this->getRawResponse($game->getName());
-		if ($response->result !== false) {
-			$game->metacritic_name = $response->result->name;
-			$game->metacritic_score = $response->result->score;
-			$game->metacritic_userscore = $response->result->userscore;
-			$game->metacritic_genre = $response->result->genre[0];
-			$game->metacritic_publisher = $response->result->publisher;
-			$game->metacritic_developer = $response->result->developer;
-			$game->metacritic_rating = $response->result->rating;
-			$game->metacritic_url = $response->result->url;
-			$game->metacritic_rlsdate = $response->result->rlsdate;
-			$game->metacritic_summary = $response->result->summary;
-			$game->metacritic_updated = date('Y-m-d H:i:s');
-			$game->save();			
-			return 'success';
-		} else {
-			$game->metacritic_updated = date('Y-m-d H:i:s');
-			$game->save();
-			return "failure";
-		}
-	}
-	
-	public function batchUpdate(\Illuminate\Database\Eloquent\Collection $games) {
 		
+	public function update(\Morpheus\SteamGame $game) {
+		return $this->updateMany(new \Illuminate\Support\Collection([$game]));
 	}
 	
-	protected function getRawResponse($name) {
-		$client = new \GuzzleHttp\Client();
-		$response = $client->get(self::API_ENDPOINT, [
-			'query' => [
-				"platform" => 'pc',
-				"title" => $name
-			],
+	public function updateMany(\ArrayAccess $games) {
+		$client = $this->getClient();		
+		$promises = [];
+		foreach ($games as $key => $game) {
+			$promises[$key] = $client->getAsync(
+					'',
+					['query' => [
+						"platform" => 'pc',
+						"title" => $game->getName()
+					]]
+			);
+		}		
+		foreach ($promises as $key => $promise) {
+			try {
+				$result = $promise->wait();
+				$this->updateGame($games[$key], $result);
+			} catch(\GuzzleHttp\Exception\RequestException $e) {
+				\Log::warning('Metacritic API call failed', ['error' => $e, 'promise' => $promise, 'game' => $games[$key]]);
+			}
+		}
+		return $games;
+    }
+	
+	protected function getClient() {
+		return new \GuzzleHttp\Client([
+			'base_uri' => self::API_ENDPOINT, 
 			"headers" => [
 				"X-Mashape-Key" => env("MASHAPE_API_KEY"),
 				'Accept' => 'application/json',
-			]
+			],
+			'http_errors' => false
 		]);
-		return json_decode($response->getBody());
+	}
+	
+	protected function updateGame(\Morpheus\SteamGame $game, \GuzzleHttp\Psr7\Response $response) {
+		$body = json_decode($response->getBody());
+		if (
+			($response->getStatusCode() == 200) && 
+			(isset($body->result)) &&
+			($body->result !== false)
+		) {
+			$game->metacritic_name = $body->result->name;
+			$game->metacritic_score = $body->result->score;
+			$game->metacritic_userscore = $body->result->userscore;
+			$game->metacritic_genre = $body->result->genre[0];
+			$game->metacritic_publisher = $body->result->publisher;
+			$game->metacritic_developer = $body->result->developer;
+			$game->metacritic_rating = $body->result->rating;
+			$game->metacritic_url = $body->result->url;
+			$game->metacritic_rlsdate = $body->result->rlsdate;
+			$game->metacritic_summary = $body->result->summary;
+		} elseif ($response->getStatusCode() !== 200) {
+			\Log::warning('Metacritic API call failed', ['status code' => $response->getStatusCode(), 'game' => $game]);
+		} elseif (!isset($body->result)) {
+			\Log::warning('Unexpected Metacritic API response', ['body' => $body, 'game' => $game]);
+		} else {
+			\Log::notice('Game not found in Metacritic database', ['game' => $game]);
+		}
+		$game->metacritic_updated = date('Y-m-d H:i:s');
+		$game->save();			
 	}
 	
 }

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -54,3 +54,10 @@ Route::any('/steam/destroy', ['as' => 'wipe_game_data', function() {
 		return redirect('')->with('error', 'Not authorized to wipe data');
 	}
 }]);
+
+Route::get('metacritic', function() {
+	$game = Morpheus\SteamGame::orderByRaw("RAND()")->first();
+	$game = Morpheus\SteamGame::where('name', "Bastion")->first();
+	$info = (new Morpheus\APIs\MetacriticGames())->update($game);
+	return response()->json([$game, $info]);
+});

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -55,9 +55,8 @@ Route::any('/steam/destroy', ['as' => 'wipe_game_data', function() {
 	}
 }]);
 
-Route::get('metacritic', function() {
-	$game = Morpheus\SteamGame::orderByRaw("RAND()")->first();
-	$game = Morpheus\SteamGame::where('name', "Bastion")->first();
-	$info = (new Morpheus\APIs\MetacriticGames())->update($game);
-	return response()->json([$game, $info]);
-});
+Route::get('metacritic/{count?}', function($count = 5) {
+	$games = Morpheus\SteamGame::where('metacritic_updated', '0000-00-00 00:00:00')->orderByRaw("RAND()")->take($count)->get();
+	(new Morpheus\APIs\MetacriticGames())->updateMany($games);
+	return response()->json($games);
+})->where('count', '[0-9]+');

--- a/app/SteamGame.php
+++ b/app/SteamGame.php
@@ -19,4 +19,8 @@ class SteamGame extends Model
 				"user_id"
 		)->withPivot('playtime_forever', 'playtime_2weeks')->withTimestamps();
 	}
+	
+	public function getName() {
+		return $this->name;
+	}
 }

--- a/database/migrations/2015_08_07_221732_create_metacritic_table.php
+++ b/database/migrations/2015_08_07_221732_create_metacritic_table.php
@@ -1,0 +1,55 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateMetacriticTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('steam_games', function (Blueprint $table) {
+			$table->string("metacritic_name");
+			$table->integer("metacritic_score")->unsigned();
+			$table->float("metacritic_userscore");
+			$table->string("metacritic_genre");
+			$table->string("metacritic_publisher");
+			$table->string("metacritic_developer");
+			$table->string("metacritic_rating", 5);
+			$table->string("metacritic_url", 200);
+			$table->date('metacritic_rlsdate');
+			$table->mediumText("metacritic_summary");
+			$table->timestamp('metacritic_updated');
+			$table->index('metacritic_updated');
+			$table->index(['metacritic_score', 'metacritic_userscore']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('steam_games', function (Blueprint $table) {
+            $table->dropColumn("metacritic_name");
+			$table->dropColumn("metacritic_score");
+			$table->dropColumn("metacritic_userscore");
+			$table->dropColumn("metacritic_genre");
+			$table->dropColumn("metacritic_publisher");
+			$table->dropColumn("metacritic_developer");
+			$table->dropColumn("metacritic_rating");
+			$table->dropColumn("metacritic_url");
+			$table->dropColumn("metacritic_rlsdate");
+			$table->dropColumn("metacritic_summary");
+			$table->dropColumn("metacritic_updated");
+			$table->dropIndex('steam_games_metacritic_updated_index');
+			$table->dropIndex('steam_games_metacritic_score_metacritic_userscore_index');			
+        });
+    }
+}

--- a/public/scripts.js
+++ b/public/scripts.js
@@ -58,6 +58,8 @@
 				"icon": game["img_icon_url"],
 				"logo": game["img_logo_url"],
 				"name": game["name"],
+				"genre": game['metacritic_genre'],
+				"rating": parseInt(game['metacritic_score']),
 				"playedAll": playedAll,
 				"playedWeeks": playedWeeks
 			}
@@ -117,9 +119,9 @@
 				"<tr>" +
 				"<td>" + icon + "</td>" +
 				"<td class='name'>" + game["name"] + "</td>" +
+				"<td>" + game["genre"] + "</td>" +
 				"<td></td>" +
-				"<td></td>" +
-				"<td></td>" +
+				"<td>" + game["rating"] + "</td>" +
 				"<td><span style='display:none;' class='playedAll'>" + game["playedAll"] + "</span>" + getPrettyTime(game["playedAll"]) + "</td>" +
 				"</tr>"
 		}


### PR DESCRIPTION
Implements metacritic support (pulling game info from an unofficial API). Requires:
1. Running a migration `php artisan migrate`
2. Updating .env file to include [Mashape api key for Metacritic API](https://www.mashape.com/byroredux/metacritic-v2) as `MASHAPE_API_KEY`

Run metacritic update via /metacritic/{item_count_to_update}

Some games are not matched automatically - currently nice solution, only possible to change the name of the game in the DB directly.
